### PR TITLE
Improve student activity registration system

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = .
+pythonpath = . src

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports activities
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in local leagues",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["lucas@mergington.edu", "mia@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball skills and play friendly matches",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["liam@mergington.edu", "ava@mergington.edu"]
+    },
+    # Artistic activities
+    "Art Club": {
+        "description": "Explore painting, drawing, and other visual arts",
+        "schedule": "Mondays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["ella@mergington.edu", "noah@mergington.edu"]
+    },
+    "Drama Society": {
+        "description": "Participate in theater productions and acting workshops",
+        "schedule": "Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 20,
+        "participants": ["amelia@mergington.edu", "jack@mergington.edu"]
+    },
+    # Intellectual activities
+    "Math Olympiad": {
+        "description": "Prepare for math competitions and solve challenging problems",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["charlotte@mergington.edu", "benjamin@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts",
+        "schedule": "Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["henry@mergington.edu", "grace@mergington.edu"]
     }
 }
 
@@ -62,6 +101,10 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+    
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -108,3 +108,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,12 +20,46 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantItems = details.participants.length > 0
+          ? details.participants.map(p =>
+              `<li class="participant-item">
+                <span>${p}</span>
+                <button class="delete-btn" data-activity="${name}" data-email="${p}" title="Unregister">&#x1F5D1;</button>
+              </li>`
+            ).join("")
+          : `<li class="no-participants">No participants yet</li>`;
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p><strong>Participants:</strong></p>
+            <ul class="participants-list">${participantItems}</ul>
+          </div>
         `;
+
+        activityCard.querySelectorAll(".delete-btn").forEach(btn => {
+          btn.addEventListener("click", async () => {
+            const activity = btn.dataset.activity;
+            const email = btn.dataset.email;
+            try {
+              const res = await fetch(
+                `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+                { method: "DELETE" }
+              );
+              if (res.ok) {
+                fetchActivities();
+              } else {
+                const err = await res.json();
+                alert(err.detail || "Failed to unregister participant.");
+              }
+            } catch (e) {
+              console.error("Error unregistering participant:", e);
+            }
+          });
+        });
 
         activitiesList.appendChild(activityCard);
 
@@ -62,6 +96,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,52 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-list {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 6px;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #555;
+  font-size: 14px;
+  padding: 3px 0;
+}
+
+.participants-list li.no-participants {
+  color: #aaa;
+  font-style: italic;
+  font-size: 14px;
+  padding: 3px 0;
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 4px;
+  color: #c62828;
+  opacity: 0.5;
+  transition: opacity 0.2s, transform 0.1s;
+  line-height: 1;
+}
+
+.delete-btn:hover {
+  opacity: 1;
+  transform: scale(1.2);
+  background: none;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,124 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+from app import app, activities as activities_store
+
+_ORIGINAL_ACTIVITIES = copy.deepcopy(activities_store)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Restore the in-memory activity data before each test."""
+    activities_store.clear()
+    activities_store.update(copy.deepcopy(_ORIGINAL_ACTIVITIES))
+    yield
+
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /activities
+# ---------------------------------------------------------------------------
+
+def test_get_activities_returns_all():
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    assert len(response.json()) == len(_ORIGINAL_ACTIVITIES)
+
+
+def test_get_activities_shape():
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    for activity in response.json().values():
+        assert "description" in activity
+        assert "schedule" in activity
+        assert "max_participants" in activity
+        assert "participants" in activity
+
+
+# ---------------------------------------------------------------------------
+# POST /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_signup_success():
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new_student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 200
+    assert email in activities_store[activity_name]["participants"]
+
+
+def test_signup_unknown_activity():
+    # Arrange
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/Unknown Activity/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+
+
+def test_signup_already_registered():
+    # Arrange
+    activity_name = "Chess Club"
+    email = activities_store[activity_name]["participants"][0]
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 400
+    assert "already signed up" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# DELETE /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_unregister_success():
+    # Arrange
+    activity_name = "Chess Club"
+    email = activities_store[activity_name]["participants"][0]
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 200
+    assert email not in activities_store[activity_name]["participants"]
+
+
+def test_unregister_unknown_activity():
+    # Arrange
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/Unknown Activity/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+
+
+def test_unregister_not_signed_up():
+    # Arrange
+    activity_name = "Chess Club"
+    email = "not_enrolled@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup?email={email}")
+
+    # Assert
+    assert response.status_code == 404
+    assert "not signed up" in response.json()["detail"]


### PR DESCRIPTION
This pull request adds support for unregistering students from activities, expands the list of available activities, improves the UI to display and manage participants, and introduces comprehensive backend tests. Additionally, it updates configuration to ensure correct module resolution during testing.

**Backend enhancements:**

* Added a DELETE endpoint (`/activities/{activity_name}/signup`) in `app.py` to allow students to unregister from activities, including error handling for unknown activities and students not signed up. Also added validation to prevent duplicate signups.
* Expanded the `activities` data in `app.py` to include sports, artistic, and intellectual activities, each with sample participants.

**Frontend improvements:**

* Updated `app.js` to display participants for each activity, including a delete button for each participant to allow unregistering via the new API. The UI now refreshes after signup or removal. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R23-R63) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R99)
* Improved the styling in `styles.css` for the participants list and delete button to enhance clarity and usability.

**Testing and configuration:**

* Added a comprehensive test suite in `test_app.py` to cover activity listing, signup, and unregistering, including edge cases and error conditions.
* Updated `pytest.ini` to include the `src` directory in the Python path for proper module resolution during testing.